### PR TITLE
docker: Fix missing packages and volume overwritting container's data

### DIFF
--- a/client.dockerfile
+++ b/client.dockerfile
@@ -4,8 +4,7 @@ WORKDIR /app
 COPY ./client/package.json ./client/package-lock.json ./
 RUN npm install
 
-ADD ./client /app
-COPY ./client/.env.example ./.env
+ADD ./client /app/
 
 EXPOSE 8080/tcp
 CMD npm run serve

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,9 @@ services:
       PORT: 8080
     working_dir: /app
     volumes:
-      - ./client:/app
+      - ./client/.env:/app/.env
+      - ./client/public:/app/public
+      - ./client/src:/app/src
     links:
       - server:server
 
@@ -37,9 +39,14 @@ services:
       DB_HOSTNAME: mysql
     working_dir: /app
     volumes:
-      - ./server:/app
-    env_file:
-      - ./server/.env
+      - ./server/app.js:/app/app.js
+      - ./server/controllers:/app/controllers
+      - ./server/controllers:/app/controllers
+      - ./server/config:/app/config
+      - ./server/models:/app/models
+      - ./server/util:/app/util
+      - ./server/routes:/app/routes
+      - ./server/seeders:/app/seeders
     links:
       - mysql:mysql
 

--- a/server.dockerfile
+++ b/server.dockerfile
@@ -1,11 +1,13 @@
 FROM node:11.6-alpine
 
+RUN apk update
+RUN apk add g++ make python
+
 WORKDIR /app
 COPY ./server/package.json ./server/package-lock.json ./
 RUN npm install
 
 ADD ./server /app
 
-COPY ./server/.env.example ./.env
 EXPOSE 3000/tcp
 CMD npm run start


### PR DESCRIPTION
First problem was missing `g++`, `make` and `python`.
Second issue is the same as last time: the volume replaces the container's directory where `npm install` ran, so the container didn't have any `node_modules` directory.