### PR TITLE
Add codebase review follow-up tasks document

### DIFF
--- a/docs/codebase-issues-tasks.md
+++ b/docs/codebase-issues-tasks.md
@@ -1,0 +1,35 @@
+# Codebase Review: Proposed Fix Tasks
+
+This document captures four concrete follow-up tasks discovered during a targeted codebase review.
+
+## 1) Typo fix
+
+- **Task:** Fix the typo `seperated` -> `separated` in a Fever controller comment.
+- **File:** `server/controllers/fever.js`
+- **Location:** Comment describing comma-separated feed IDs.
+
+## 2) Bug fix
+
+- **Task:** Enforce category ownership checks by user for read/update/delete handlers.
+- **File:** `server/controllers/category.js`
+- **Issue summary:** Several handlers use `findByPk` without robust ownership constraints, which can allow cross-user access/mutation if IDs are guessed.
+- **Suggested fix:** Use user-scoped lookups (e.g., `findOne({ where: { id: categoryId, userId } })`) before update/delete.
+
+## 3) Documentation discrepancy fix
+
+- **Task:** Reconcile API status code docs with actual endpoint behavior.
+- **Files:**
+  - `docs/api.md`
+  - `server/controllers/category.js`
+- **Issue summary:** Docs state `204` for deletions/updates, but `updateCategory` returns `200` with a response body.
+- **Suggested fix:** Either update docs to reflect mixed behavior, or normalize controller status codes.
+
+## 4) Test improvement
+
+- **Task:** Add regression tests for category ownership authorization.
+- **Target folder:** `server/tests/`
+- **Coverage to add:**
+  - GET category by ID rejects foreign-user category
+  - PUT category by ID rejects foreign-user category
+  - DELETE category by ID rejects foreign-user category
+


### PR DESCRIPTION
### Motivation

- Capture and track four concrete follow-up items discovered during a targeted codebase review so they are easy to prioritize and assign. 
- Surface a potential security/authorization bug around category ownership checks that could allow cross-user access if IDs are guessed. 
- Record documentation and test gaps to ensure API docs and automated coverage match actual behavior.

### Description

- Add `docs/codebase-issues-tasks.md` that lists four actionable tasks: a typo fix, a category ownership bug fix, an API docs/status-code discrepancy fix, and tests to cover category ownership. 
- Note the exact files and locations referenced for each task, including `server/controllers/fever.js`, `server/controllers/category.js`, `docs/api.md`, and `server/tests/` as targets. 
- Recommend specific changes such as changing `findByPk` lookups to user-scoped `findOne({ where: { id: ..., userId } })` and reconciling `204` vs `200` behavior. 
- Propose adding regression tests to verify GET/PUT/DELETE for categories reject access from other users.

### Testing

- No automated tests were run for this documentation-only change. 
- No code behavior was modified in this PR, so no test failures were introduced by these edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a144f99009c83319e902c632b0b6469)