### PR TITLE
Adjust recommendation weighting to favor cross-source corroboration

### DIFF
--- a/server/util/recommendedScore.js
+++ b/server/util/recommendedScore.js
@@ -61,15 +61,15 @@ export function computeRecommended(article) {
   const ruleBoost = hasRuleTag ? 0.15 : 0;
 
   // Weighted sum: balances all signals to produce recommended score (0–1)
-  // Weights: freshness (49%), interest (15%), quality (6%), coverage (16%), crossSource (8%), corroboration (6%)
+  // Weights: freshness (40%), interest (15%), quality (6%), coverage (15%), crossSource (12%), corroboration (12%)
   // Plus a flat 0.15 boost for rule-tagged articles
   const recommended =
     0.06 * quality +
-    0.49 * freshness +
+    0.40 * freshness +
     0.15 * interestScore +
-    0.16 * coverage +
-    0.08 * crossSource +
-    0.06 * corroboration +
+    0.15 * coverage +
+    0.12 * crossSource +
+    0.12 * corroboration +
     ruleBoost;
 
   return Math.max(0, Math.min(1, recommended));
@@ -116,11 +116,11 @@ export function computeRecommendedBreakdown(article) {
 
   const recommended = Math.max(0, Math.min(1,
     0.06 * quality +
-    0.49 * freshness +
+    0.40 * freshness +
     0.15 * interestScore +
-    0.16 * coverage +
-    0.08 * crossSource +
-    0.06 * corroboration +
+    0.15 * coverage +
+    0.12 * crossSource +
+    0.12 * corroboration +
     ruleBoost
   ));
 


### PR DESCRIPTION
### Motivation
- Rebalance `computeRecommended` to prefer articles corroborated by multiple unique publishers over strict recency, improving semantic stability and reducing noise.

### Description
- Increased weights for `crossSource` and `corroboration` and reduced `freshness` in `server/util/recommendedScore.js`, and synchronized the same change in `computeRecommendedBreakdown` and the inline weighting comment.

### Testing
- Ran `cd server && npm test -- --run tests/recommendedScore.test.js tests/articleSearch.recommended.include.test.js` and both test files passed; the DB-dependent `assignArticleToEvent` suite could not run here due to a MySQL connection refused error (environment), so it was not treated as a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1454a9198c833182434540eac25a1b)