### PR TITLE
fix: upgrade postcss to 8.5.18 (GHSA-r28c-9q8g-f849)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4683,9 +4683,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/server/package.json
+++ b/server/package.json
@@ -79,5 +79,8 @@
   },
   "optionalDependencies": {
     "fsevents": "^2.3.3"
+  },
+  "overrides": {
+    "postcss": "8.5.18"
   }
 }


### PR DESCRIPTION
## Summary
Upgrade postcss from 8.5.16 to 8.5.18 to fix GHSA-r28c-9q8g-f849.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-r28c-9q8g-f849 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-r28c-9q8g-f849` |
| **File** | `server/package-lock.json` |
| **Assessment** | Pattern match — needs manual review |

**Description**: PostCSS: Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure

## Evidence

**Scanner confirmation**: trivy rule `GHSA-r28c-9q8g-f849` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `server/package.json`
- `server/package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
