### PR TITLE
Potential fix for code scanning alert no. 162: Incomplete URL substring sanitization

### DIFF
--- a/client/src/components/articles/ArticleHeader.vue
+++ b/client/src/components/articles/ArticleHeader.vue
@@ -44,7 +44,13 @@ export default {
   computed: {
     // Returns whether the article links to a Bluesky profile post.
     isBlueSkyArticle() {
-      return this.url.includes('https://bsky.app/profile/') || this.url.includes('http://bsky.app/profile/');
+      try {
+        const parsedUrl = new URL(this.url);
+        const isHttp = parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+        return isHttp && parsedUrl.hostname.toLowerCase() === 'bsky.app' && parsedUrl.pathname.startsWith('/profile/');
+      } catch (e) {
+        return false;
+      }
     },
     // Returns whether the article links to Reddit.
     isRedditArticle() {


### PR DESCRIPTION
Potential fix for [https://github.com/pietheinstrengholt/rssmonster/security/code-scanning/162](https://github.com/pietheinstrengholt/rssmonster/security/code-scanning/162)

To fix this safely, parse `this.url` with the built-in `URL` class, then validate:
1. Protocol is `http:` or `https:`
2. Host is exactly `bsky.app`
3. Path starts with `/profile/`

This avoids substring bypasses and preserves intended functionality (“Bluesky profile post” detection).  
Best single change: replace the body of `isBlueSkyArticle()` in `client/src/components/articles/ArticleHeader.vue` with a `try/catch` parser-based check (return `false` on parse failure).

No new imports or dependencies are needed, since `URL` is standard JavaScript.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
