### PR TITLE
fix(feeds): read media:group description for video entries

### DIFF
--- a/server/services/feeds/feedsmith/normalizeEntry.js
+++ b/server/services/feeds/feedsmith/normalizeEntry.js
@@ -148,6 +148,23 @@ const resolveContent = (entry, feedFormat) => {
   return { value: null, kind: null };
 };
 
+// This function returns the first Media RSS group description text. Video feeds such
+// as YouTube carry their synopsis only in media:group/media:description and provide no
+// summary or content element, so without this they normalize to an empty body.
+const resolveMediaGroupDescription = entry => {
+  const groups = [
+    ...(entry?.media?.group ? [entry.media.group] : []),
+    ...(Array.isArray(entry?.media?.groups) ? entry.media.groups : [])
+  ];
+  for (const group of groups) {
+    const value = group?.description?.value ?? group?.description;
+    if (hasTextValue(value)) {
+      return value;
+    }
+  }
+  return null;
+};
+
 // This function selects summary content and its safest known interpretation.
 const resolveDescription = (entry, feedFormat) => {
   if (hasTextValue(entry.description)) {
@@ -169,6 +186,10 @@ const resolveDescription = (entry, feedFormat) => {
       value: entry.atom.summary,
       kind: normalizeContentKind(entry.atom.summaryKind)
     };
+  }
+  const mediaGroupDescription = resolveMediaGroupDescription(entry);
+  if (hasTextValue(mediaGroupDescription)) {
+    return { value: mediaGroupDescription, kind: 'text' };
   }
   return { value: null, kind: null };
 };

--- a/server/tests/feeds/feedsmithAdapter.test.js
+++ b/server/tests/feeds/feedsmithAdapter.test.js
@@ -482,4 +482,43 @@ describe('Feedsmith adapter', () => {
       })
     ]));
   });
+
+  it('uses the Media RSS group description when a video entry has no summary or content', () => {
+    const feed = parseFeedSource(`
+      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>Video channel</title><id>video-feed</id>
+        <entry>
+          <title>Episode one</title><id>yt:video:abc123</id>
+          <link href="https://videos.example/watch?v=abc123" />
+          <media:group>
+            <media:title>Episode one</media:title>
+            <media:description>How the build was filmed.</media:description>
+          </media:group>
+        </entry>
+      </feed>
+    `, { feedUrl: 'https://videos.example/feeds/videos.xml' });
+
+    expect(feed.entries[0]).toMatchObject({
+      description: 'How the build was filmed.',
+      descriptionKind: 'text'
+    });
+  });
+
+  it('prefers a declared summary over the Media RSS group description', () => {
+    const feed = parseFeedSource(`
+      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>Video channel</title><id>video-feed</id>
+        <entry>
+          <title>Episode two</title><id>yt:video:def456</id>
+          <link href="https://videos.example/watch?v=def456" />
+          <summary>Canonical summary.</summary>
+          <media:group>
+            <media:description>Fallback description.</media:description>
+          </media:group>
+        </entry>
+      </feed>
+    `, { feedUrl: 'https://videos.example/feeds/videos.xml' });
+
+    expect(feed.entries[0].description).toBe('Canonical summary.');
+  });
 });


### PR DESCRIPTION
Atom feeds for video platforms (YouTube among them) carry the entry synopsis
only in media:group/media:description and emit no summary or content element.
resolveDescription never consulted the Media RSS group, so those entries
normalized to an empty description.

Downstream this meant such entries were stored with no body text at all: they
produced no embeddings, never joined an event cluster, and every article fell
back to the neutral 0.700 quality default, which excluded them from any
quality-filtered Smart Folder.

Read media:group/media:description as a last resort, after description,
summary and atom:summary, so declared summaries keep precedence and only
entries that would otherwise be empty are affected. Feedsmith exposes the
value on both media.group and media.groups[], so both shapes are checked.

Co-Authored-By: Claude Opus 5
