### PR TITLE
Publish the inference Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,12 +180,7 @@ jobs:
           docker compose -f docker-compose.mysql.yml config > /dev/null
 
       - name: Build inference Docker image
-        env:
-          JWT_SECRET: ci-jwt-secret
-          FEVER_CREDENTIAL_SECRET: ci-fever-credential-secret
-          DB_PASSWORD: ci-database-password
-          MYSQL_ROOT_PASSWORD: ci-root-database-password
-        run: docker compose -f docker-compose.mysql.yml build inference
+        run: docker build -t rssmonster-inference:ci ./inference
 
   client:
     name: Client

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,8 +77,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract Docker metadata
-        id: meta
+      - name: Extract application Docker metadata
+        id: app-meta
         uses: docker/metadata-action@v6
         with:
           images: rssmonster/rssmonster
@@ -92,8 +92,23 @@ jobs:
             org.opencontainers.image.revision=${{ steps.commit.outputs.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
-      - name: Build and push
-        id: build
+      - name: Extract inference Docker metadata
+        id: inference-meta
+        uses: docker/metadata-action@v6
+        with:
+          images: rssmonster/rssmonster-inference
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_run' }}
+            type=raw,value=sha-${{ steps.commit.outputs.short_sha }}
+            type=ref,event=tag
+          labels: |
+            org.opencontainers.image.title=RSSMonster Inference
+            org.opencontainers.image.description=Inference service for RSSMonster
+            org.opencontainers.image.revision=${{ steps.commit.outputs.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Build and push application
+        id: app-build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -101,10 +116,26 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           pull: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.app-meta.outputs.tags }}
+          labels: ${{ steps.app-meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Build and push inference
+        id: inference-build
+        uses: docker/build-push-action@v7
+        with:
+          context: ./inference
+          file: ./inference/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          pull: true
+          tags: ${{ steps.inference-meta.outputs.tags }}
+          labels: ${{ steps.inference-meta.outputs.labels }}
+          cache-from: type=gha,scope=inference
+          cache-to: type=gha,mode=max,scope=inference
           provenance: mode=max
           sbom: true
 
@@ -112,12 +143,17 @@ jobs:
         shell: bash
         run: |
           {
-            echo "## Docker image published"
+            echo "## Docker images published"
             echo
             echo "- Commit: \`${{ steps.commit.outputs.sha }}\`"
-            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
-            echo "- Tags:"
+            echo "- Application digest: \`${{ steps.app-build.outputs.digest }}\`"
+            echo "- Inference digest: \`${{ steps.inference-build.outputs.digest }}\`"
+            echo "- Application tags:"
             echo '```'
-            echo "${{ steps.meta.outputs.tags }}"
+            echo "${{ steps.app-meta.outputs.tags }}"
+            echo '```'
+            echo "- Inference tags:"
+            echo '```'
+            echo "${{ steps.inference-meta.outputs.tags }}"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -229,9 +229,7 @@ services:
       - rssmonster-network
 
   inference:
-    build:
-      context: ./inference
-      dockerfile: Dockerfile
+    image: "${RSSMONSTER_INFERENCE_IMAGE:-rssmonster/rssmonster-inference:${RSSMONSTER_TAG:-latest}}"
     container_name: rssmonster-inference
     restart: unless-stopped
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,10 +156,12 @@ FEVER_CREDENTIAL_SECRET=replace-with-a-different-long-random-secret
 Then use the separate MySQL Compose configuration:
 
 ```bash
-docker compose -f docker-compose.mysql.yml up -d --build
+docker compose -f docker-compose.mysql.yml up -d --pull always
 ```
 
-On first startup, the inference service downloads its models into the persistent
+The application and inference images are pulled from Docker Hub, so image
+updaters such as Watchtower can keep the complete deployment current without a
+local source checkout or build. On first startup, the inference service downloads its models into the persistent
 `inference-model-cache` volume. RSSMonster and both workers wait for MySQL and
 inference to become healthy before starting. MySQL data is stored in the
 `mysql-data` volume. Downloads can take several minutes depending on the host


### PR DESCRIPTION
## Summary
- publish `rssmonster/rssmonster-inference` alongside the application image, with matching `latest`, commit SHA, and release tags
- use the published inference image in the full MySQL Compose profile instead of requiring a local source build
- keep the inference Dockerfile build covered explicitly by CI
- document pull-only full-stack startup, enabling image updaters such as Watchtower

## Motivation
The full Compose profile currently mixes a registry image for the application with a local build for inference. That prevents image-only update managers from updating the complete stack and requires users to retain a source checkout. Publishing both images from the same tested commit keeps them aligned and makes the full deployment genuinely image-based.

## Validation
- Compose continues to allow an override through `RSSMONSTER_INFERENCE_IMAGE`
- application and inference images use identical tag rules and source revision labels
- inference Dockerfile remains built by CI